### PR TITLE
add error message if cannot connect to MongoDB, terminte process

### DIFF
--- a/Node_Express/app.js
+++ b/Node_Express/app.js
@@ -16,9 +16,12 @@ const start = async () =>{//connect to MongoDB
         app.listen(port, ()=>{
             console.log(`Server is listening at port ${port}.....`)
     })
-    }catch(error){
-        console.log(error)
+    }
+    catch(error){
+        console.error('Cannot connect to MongoDB:', error);
+        process.exit(1);
     }
 }
 
 start()
+  


### PR DESCRIPTION
Title: optimized error handling

Problem: error message for not connecting to MongoDB not descriptive enough, process not terminated if there are still async function running

Solution: add new message to indicate cannot connect to MongoDB, use process.exit(1) if error is caught

TicketID: 2

